### PR TITLE
Remove access of parent folder from init() function

### DIFF
--- a/lib/core/Context.js
+++ b/lib/core/Context.js
@@ -62,6 +62,39 @@ const TASKS =
     "initTransforms"
 ];
 
+const WORKSPACE_FILES =
+{
+    sources: [
+        "ContextSource.js",
+        "FileSource.js",
+        "HttpSource.js",
+        "HttpsSource.js",
+        "ModulepathSource.js"
+    ],
+    builders: [
+        "ConfigBuilder.js",
+        "ContentBuilder.js",
+        "ScriptBuilder.js",
+        "ValueBuilder.js"
+    ],
+    transforms: [
+        "Base64DecodeTransform.js",
+        "Base64EncodeTransform.js",
+        "EvalTransform.js",
+        "FilterTransform.js",
+        "HashTransform.js",
+        "InvokeTransform.js",
+        "MapTransform.js",
+        "QueryTransform.js",
+        "ReduceTransform.js",
+        "SliceTransform.js",
+        "SortTransform.js",
+        "TrimTransform.js",
+        "UniqueTransform.js"
+    ]
+};
+
+
 
 
 class Context
@@ -960,7 +993,7 @@ function init ()
 {
     for (let d of ["sources", "builders", "transforms"])
     {
-        let files = _.readDirSync (no_path.join (__dirname, "..", d), _.readDirSync.TYPE.FILE);
+        let files = WORKSPACE_FILES[d];
 
         for (let f of files)
         {


### PR DESCRIPTION
The `init()` function present in `lib/core/Context.js` finding files present in `"sources", "builders", "transforms" `folders which is one level up in the source code. 

While bundling this package into node application using Nx/Webpack,  then in main.js i.e. the final bundle file, there is no parent directory preset with these mentioned names.  This was giving error while initializing. 

I have moved all the file names in the const `WORKSPACE_FILES` and removed the access to the fileSystem for finding all the file names.