### PR TITLE
Add null check to `require.main`

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -30,7 +30,7 @@ async function parser (opts)
 
 async function registerPlugins ()
 {
-    if (parser.$mode == "cli" && require.main.filename.startsWith (no_path.dirname (__dirname)))
+    if (parser.$mode == "cli" && require.main?.filename.startsWith (no_path.dirname (__dirname)))
     {
         let userConfig = await Context.resolve ({ url: no_path.join (parser.$homedir, ".pushcorn.conf") }) || {};
 


### PR DESCRIPTION
`require.main` doesn't exist in deno and as such crashes